### PR TITLE
deps: stage 3 — darts 0.43 + xgboost 3.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-darts[all]>=0.36.0
+darts[all]>=0.43
 pandas>=3.0,<4
 numpy>=2.1
 prophet>=1.3
@@ -6,7 +6,7 @@ scikit-learn>=1.8
 torch>=2.10,<2.11
 # tensorflow>=2.15.0
 lightgbm>=4.6
-xgboost>=2.1.0
+xgboost>=3.2
 python-dateutil>=2.9
 requests>=2.32.0
 catboost>=1.2.8


### PR DESCRIPTION
## Summary

Stage 3 of the dependency modernization plan: upgrade darts to 0.43 and xgboost to 3.2.

- Bump `darts[all]>=0.36.0` → `darts[all]>=0.43`
- Bump `xgboost>=2.1.0` → `xgboost>=3.2`
- Maintain `torch>=2.10,<2.11` cap (Stage 2 constraint)

## Validation Results

### Import Smoke Tests
✅ All darts imports working (TimeSeries, metrics, baselines, SeasonalityMode, XGBModel)
✅ XGBModel fit/train working with xgboost 3.2

### Test Suite
✅ pytest: 27/27 tests passed
✅ Warnings sweep: No deprecation/future warnings in application code (only third-party fugue plugin warning)

### Production Forecast
✅ `run_production_forecast.py`: Completed successfully (exit 0, ~24 minutes)
✅ CVE forecasts: 13 models trained
✅ CNA forecasts: 130/131 CNAs forecasted
✅ `validate_forecast_data.py`: Passed

### Baseline Comparison
✅ Model rankings identical (TBATS, XGBoost, FourTheta top 3)
✅ MAPE values identical across all 13 models
✅ No order-of-magnitude drift

## Code Changes

No code changes required - darts 0.43 and xgboost 3.2 are fully backward compatible with the existing codebase.

## Supersedes

Closes #22 (xgboost dependency update)
Closes #23 (darts dependency update)

---

🤖 Generated with Claude Code