### PR TITLE
fix(ci): use CPU-only torch wheel and rebase before daily push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,11 +2,11 @@ name: CVE Forecast Daily Update
 
 on:
   push:
-    branches: [ main, master ]
+    branches: [main, master]
   schedule:
     # Run daily at midnight UTC
-    - cron: '0 0 * * *'
-  
+    - cron: "0 0 * * *"
+
   # Allow manual triggering
   workflow_dispatch:
 
@@ -26,79 +26,80 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    
+
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
-        token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Set up Python
-      uses: actions/setup-python@v6
-      with:
-        python-version: '3.13'
-        cache: 'pip'
-    
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-    
-    - name: Configure Git
-      run: |
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-    
-    - name: Clone CVE data repository
-      run: |
-        git clone --depth 1 https://github.com/CVEProject/cvelistV5.git cvelistV5
-        echo "CVE data cloned successfully"
-        ls -la cvelistV5/
-    
-    - name: Run CVE forecast
-      run: |
-        python code/run_production_forecast.py
-      env:
-        PYTHONUNBUFFERED: 1
-    
-    - name: Validate forecast data
-      run: python code/scripts/validate_forecast_data.py
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+          cache: "pip"
 
-    - name: Check for changes
-      id: verify-changed-files
-      run: |
-        if [ -n "$(git status --porcelain)" ]; then
-          echo "changed=true" >> $GITHUB_OUTPUT
-        else
-          echo "changed=false" >> $GITHUB_OUTPUT
-        fi
-    
-    - name: Commit and push changes
-      if: steps.verify-changed-files.outputs.changed == 'true'
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        git add web/data.json web/cna_data.json web/forecast_history.json web/pipeline_results.json web/model_info.json || true
-        git commit -m "Update CVE forecast data - $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
-        git push
-    
-    - name: Upload artifacts
-      if: always()
-      uses: actions/upload-artifact@v7
-      with:
-        name: forecast-data
-        path: web/data.json
-        retention-days: 30
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
 
-    - name: Setup Pages
-      uses: actions/configure-pages@v6
+      - name: Configure Git
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
 
-    - name: Upload to GitHub Pages
-      uses: actions/upload-pages-artifact@v5
-      with:
-        path: web/
-    
-    - name: Deploy to GitHub Pages
-      id: deployment
-      uses: actions/deploy-pages@v5
+      - name: Clone CVE data repository
+        run: |
+          git clone --depth 1 https://github.com/CVEProject/cvelistV5.git cvelistV5
+          echo "CVE data cloned successfully"
+          ls -la cvelistV5/
+
+      - name: Run CVE forecast
+        run: |
+          python code/run_production_forecast.py
+        env:
+          PYTHONUNBUFFERED: 1
+
+      - name: Validate forecast data
+        run: python code/scripts/validate_forecast_data.py
+
+      - name: Check for changes
+        id: verify-changed-files
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit and push changes
+        if: steps.verify-changed-files.outputs.changed == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git add web/data.json web/cna_data.json web/forecast_history.json web/pipeline_results.json web/model_info.json || true
+          git commit -m "Update CVE forecast data - $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+          git pull --rebase origin main
+          git push
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: forecast-data
+          path: web/data.json
+          retention-days: 30
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v6
+
+      - name: Upload to GitHub Pages
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: web/
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/monthly_tuning.yml
+++ b/.github/workflows/monthly_tuning.yml
@@ -34,7 +34,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
           pip install -r requirements.txt
 
       - name: Configure Git

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+--extra-index-url https://download.pytorch.org/whl/cpu
 darts[all]>=0.43
 pandas>=3.0,<4
 numpy>=2.1


### PR DESCRIPTION
## Summary

Three issues surfaced in CI after the dependency modernization landed:

1. **Tests and Monthly Tuning were failing with `[Errno 28] No space left on device`** during `pip install -r requirements.txt`. Root cause: torch's default PyPI wheel ships the full CUDA runtime (~5 GB across `nvidia-cublas-cu12`, `nvidia-cudnn-cu12`, `nvidia-cusparselt-cu12`, etc.). Runners don't have GPUs, so the CUDA payload is pure waste — and combined with `darts[all]` + `scipy` + `statsmodels`, the install exceeded the runner's disk budget.

2. **Monthly Tuning had a pre-install shim** (`pip install torch ... --index-url https://download.pytorch.org/whl/cpu` before the `-r requirements.txt` line) that stopped working because the subsequent requirements install upgraded torch back to the PyPI CUDA wheel.

3. **Daily forecast push occasionally failed** with a git fast-forward reject race when another commit landed between clone and push.

## Changes

- `requirements.txt` — add `--extra-index-url https://download.pytorch.org/whl/cpu` at the top so every pip install (CI and local) resolves torch from the CPU wheel index. This fixes both #1 and #2 in one line.
- `.github/workflows/monthly_tuning.yml` — remove the now-redundant pre-install shim.
- `.github/workflows/main.yml` — add `git pull --rebase origin main` before the daily `git push`, mirroring what `monthly_tuning.yml` already does.

## Test plan

- [ ] CI on this PR: `Tests` (test.yml) and `Lint` pass.
- [ ] After merge: next scheduled `CVE Forecast Daily Update` run succeeds.
- [ ] Next monthly tuning run (or a manual `workflow_dispatch`) succeeds.

## Notes

The `--extra-index-url` directive in `requirements.txt` applies to all environments — local dev will also pull CPU torch on fresh installs. That's the intended behavior (project doesn't target GPU execution), but flagging so anyone using a GPU-enabled venv knows to install torch separately first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)