### PR TITLE
fix(ci): use --autostash on daily forecast rebase

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           git add web/data.json web/cna_data.json web/forecast_history.json web/pipeline_results.json web/model_info.json || true
           git commit -m "Update CVE forecast data - $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
-          git pull --rebase origin main
+          git pull --rebase --autostash origin main
           git push
 
       - name: Upload artifacts


### PR DESCRIPTION
## Summary

The rebase-before-push fix in #30 exposed a second issue: the production forecast run dirties files beyond the five we explicitly stage (most likely `code/cna_count_cache.json`), so `git pull --rebase` after the commit fails with:

```
error: cannot pull with rebase: You have unstaged changes.
error: Please commit or stash them.
```

Adding `--autostash` lets rebase stash the dirty tree automatically and restore it afterward. One-line change.

## Evidence

Failing run on main after #30: https://github.com/RogoLabs/CVEForecast/actions/runs/25073725056

## Test plan

- [ ] CI green on this PR (Lint + Tests).
- [ ] Post-merge, next daily forecast run succeeds through the push step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)